### PR TITLE
Replace the journey board's sample trips with the real ones

### DIFF
--- a/components/journey/gate-panel.tsx
+++ b/components/journey/gate-panel.tsx
@@ -1,8 +1,10 @@
-import { DerivedTrip, HOME_CODE, formatRange } from '../../lib/journey';
+import { DerivedTrip, HOME_CODE, formatRange, formatStart, precisionOf } from '../../lib/journey';
 
 const countdown = (trip: DerivedTrip): string => {
   if (trip.phase === 'enroute') return 'In the air';
   if (trip.phase === 'boarding') return 'Boarding today';
+  // Counting down to the day needs a date that is known to the day.
+  if (precisionOf(trip) !== 'day') return `Departs ${formatStart(trip)}`;
   if (trip.daysAway === 1) return 'Departs tomorrow';
   return `Departs in ${trip.daysAway} days`;
 };

--- a/components/journey/globe-panel.tsx
+++ b/components/journey/globe-panel.tsx
@@ -7,6 +7,7 @@ import {
   Place,
   formatRange,
   groupPlaces,
+  precisionOf,
   routeKm,
 } from '../../lib/journey';
 
@@ -35,14 +36,24 @@ function PlaceTooltip({ place, hit }: { place: Place; hit: GlobeHit }) {
         {place.country} · {place.visits.length} {place.visits.length === 1 ? 'trip' : 'trips'}
       </p>
       <ul className="mt-2 flex flex-col gap-1 border-t border-neutral-200 pt-2 dark:border-neutral-800">
-        {place.visits.map((visit) => (
-          <li key={visit.id} className="flex items-baseline justify-between gap-2 text-[0.7rem]">
-            <span className="tabular-nums">{visit.year}</span>
-            <span className="text-neutral-500 dark:text-neutral-400">
-              {visit.phase === 'resident' ? 'Home' : formatRange(visit)}
-            </span>
-          </li>
-        ))}
+        {place.visits.map((visit) => {
+          // The year is already the left column, so a year-only trip has
+          // nothing left to say on the right.
+          const detail =
+            visit.phase === 'resident'
+              ? 'Home'
+              : precisionOf(visit) === 'year'
+                ? null
+                : formatRange(visit);
+          return (
+            <li key={visit.id} className="flex items-baseline justify-between gap-2 text-[0.7rem]">
+              <span className="tabular-nums">{visit.year}</span>
+              {detail && (
+                <span className="text-neutral-500 dark:text-neutral-400">{detail}</span>
+              )}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );
@@ -56,15 +67,17 @@ function Caption({ home, focused }: { home: DerivedTrip; focused: DerivedTrip | 
       </span>
     );
   }
+  // Most legs leave from home; the handful that did not name their real origin.
+  const from = focused.origin ?? { code: HOME_CODE, geo: home.geo };
   return (
     <div className="flex flex-col gap-1">
       <span className="text-sm">
-        <span className="text-neutral-500 dark:text-neutral-500">{HOME_CODE}</span>
+        <span className="text-neutral-500 dark:text-neutral-500">{from.code}</span>
         <span className="px-2 text-orange-500">→</span>
         <span className="font-semibold">{focused.iata}</span>
       </span>
       <span className="text-[0.7rem] uppercase tracking-[0.15em] text-neutral-500 dark:text-neutral-500">
-        {focused.city} · {routeKm(home.geo, focused).toLocaleString('en-US')} km
+        {focused.city} · {routeKm(from.geo, focused).toLocaleString('en-US')} km
       </span>
     </div>
   );
@@ -90,7 +103,10 @@ export default function GlobePanel({
   const hovered = hit ? (places.find((place) => place.id === hit.id) ?? null) : null;
 
   const focus = useMemo(
-    () => (focused && focused.id !== home.id ? { geo: focused.geo, via: focused.via } : null),
+    () =>
+      focused && focused.id !== home.id
+        ? { geo: focused.geo, via: focused.via, from: focused.origin?.geo }
+        : null,
     [focused, home.id]
   );
 

--- a/components/journey/globe.tsx
+++ b/components/journey/globe.tsx
@@ -5,7 +5,12 @@ import { landDots } from '../../lib/land-dots';
 export type GlobePoint = { id: string; geo: [number, number] };
 
 /** The hovered destination, plus any waypoints its route is routed through. */
-export type GlobeFocus = { geo: [number, number]; via?: [number, number][] };
+export type GlobeFocus = {
+  geo: [number, number];
+  via?: [number, number][];
+  /** Where the leg took off from. Defaults to home. */
+  from?: [number, number];
+};
 
 /** A marker under the pointer, with where it sits on screen in CSS pixels. */
 export type GlobeHit = { id: string; x: number; y: number };
@@ -323,8 +328,9 @@ export default function Globe({
 
     const buildArc = (next: GlobeFocus) => {
       clearArc();
+      const start = next.from ? toVector(next.from[0], next.from[1]) : home;
       const waypoints = (next.via ?? []).map(([lon, lat]) => toVector(lon, lat));
-      arcCurrent = arcCurve([home, ...waypoints, toVector(next.geo[0], next.geo[1])]);
+      arcCurrent = arcCurve([start, ...waypoints, toVector(next.geo[0], next.geo[1])]);
       arcMesh = new THREE.Mesh(
         new THREE.TubeGeometry(arcCurrent, 120, 0.008, 8, false),
         arcMaterial
@@ -513,7 +519,9 @@ export default function Globe({
       if (!onScreen || document.hidden) return;
 
       const focus = focusRef.current;
-      const key = focus ? `${focus.geo[0]},${focus.geo[1]}` : '';
+      // The whole route identifies the arc, not just its endpoint — two trips
+      // can land in the same city from different places.
+      const key = focus ? `${focus.from ?? ''}>${focus.via ?? ''}>${focus.geo}` : '';
       if (key !== lastFocusKey) {
         lastFocusKey = key;
         // A new destination takes the globe back from the pointer.

--- a/lib/journey.ts
+++ b/lib/journey.ts
@@ -14,6 +14,12 @@ export type Continent =
   | 'Africa'
   | 'Oceania';
 
+/**
+ * How much of the date is actually known. The board never renders more
+ * precision than it has: a 'year' trip shows "2019", never an invented day.
+ */
+export type Precision = 'day' | 'month' | 'year';
+
 export type Trip = {
   /** Stable key, kebab-case. */
   id: string;
@@ -25,6 +31,11 @@ export type Trip = {
   /** [longitude, latitude] — where the globe puts the marker. */
   geo: [number, number];
   /**
+   * Where this leg took off from, when it was not home. Leave it off and the
+   * route is drawn from Paris, which is true of almost everything here.
+   */
+  origin?: { code: string; city: string; geo: [number, number] };
+  /**
    * Waypoints the route passes through, as [lon, lat]. Leave this off and the
    * globe draws the great circle, which is what aircraft actually fly on most
    * routes. Set it for the ones where airspace pushes the real track off the
@@ -35,6 +46,8 @@ export type Trip = {
   startDate: string;
   /** YYYY-MM-DD. Omit for a single day or an open-ended stay. */
   endDate?: string;
+  /** Defaults to 'day'. Set it lower and the board rounds what it prints. */
+  precision?: Precision;
   /**
    * `resident` pins the row to the top of Arrivals with a live indicator.
    * `lived` is for somewhere you stayed a while but have since left.
@@ -49,18 +62,57 @@ export type Trip = {
 };
 
 /** The year the board counts from, shown in the header stats. */
-export const JOURNEY_SINCE = 2018;
+export const JOURNEY_SINCE = 2006;
 
 /** Your IATA-ish code, used across the header and board titles. */
 export const HOME_CODE = 'TCD';
 export const HOME_NAME = 'THOMAS CHARDONNENS INTL';
 
 // ─────────────────────────────────────────────────────────────────────────────
+//  Routings
+//
+//  Since 2022 nothing westbound-to-Asia crosses Russia, so the real tracks bow
+//  a long way south of the great circle. These are approximate published
+//  routings — close enough to be honest, not recorded ADS-B traces.
+// ─────────────────────────────────────────────────────────────────────────────
+const VIA_KOREA: [number, number][] = [
+  [19.0, 47.5], // Hungary
+  [33.0, 40.0], // central Türkiye
+  [52.0, 40.5], // Caspian / Turkmenistan
+  [67.0, 42.5], // Uzbekistan
+  [87.0, 44.0], // Ürümqi, Xinjiang
+  [110.0, 41.5], // Inner Mongolia
+];
+
+const VIA_SHANGHAI: [number, number][] = [
+  [19.0, 47.5], // Hungary
+  [33.0, 40.0], // central Türkiye
+  [52.0, 40.5], // Caspian / Turkmenistan
+  [67.0, 42.5], // Uzbekistan
+  [87.0, 43.0], // Xinjiang
+  [103.0, 37.0], // Gansu corridor
+];
+
+const VIA_HONG_KONG: [number, number][] = [
+  [19.0, 47.5], // Hungary
+  [33.0, 40.0], // central Türkiye
+  [52.0, 40.0], // Caspian / Turkmenistan
+  [67.0, 41.0], // Uzbekistan
+  [82.0, 38.5], // Tarim basin
+  [99.0, 31.0], // western Sichuan
+];
+
+const PARIS: [number, number] = [2.35, 48.86];
+const PAPEETE: [number, number] = [-149.57, -17.55];
+const SHANGHAI: [number, number] = [121.47, 31.23];
+
+// ─────────────────────────────────────────────────────────────────────────────
 //  TRIPS
 //
-//  The first three are real. Everything below the SAMPLES marker is a
-//  placeholder so the board looks populated in dev — replace or delete those
-//  before you deploy. Order here does not matter; the board sorts by date.
+//  Listed oldest first; the board sorts itself. Most of these carry only a
+//  year, which is all that was recorded — set `precision: 'month'` or drop it
+//  entirely (defaulting to 'day') as you pin the real dates down, and the
+//  board starts printing them without any other change.
 // ─────────────────────────────────────────────────────────────────────────────
 export const TRIPS: Trip[] = [
   {
@@ -69,131 +121,286 @@ export const TRIPS: Trip[] = [
     country: 'France',
     iata: 'CDG',
     continent: 'Europe',
-    geo: [2.35, 48.86],
-    startDate: `${JOURNEY_SINCE}-09-01`, // adjust to when you actually landed here
+    geo: PARIS,
+    startDate: '2009-01-01',
+    precision: 'year',
     status: 'resident',
     region: 'France · Home',
     note: 'Home base. Everything else on this board leaves from here.',
   },
+
+  // ─── 2006–2009 · the Pacific years ────────────────────────────────────────
   {
-    id: 'berkeley-2023',
-    city: 'Berkeley',
-    country: 'United States',
-    iata: 'SFO',
-    continent: 'North America',
-    geo: [-122.27, 37.87],
-    startDate: '2023-08-14',
-    endDate: '2023-12-15',
+    id: 'papeete-2006',
+    city: 'Papeete',
+    country: 'French Polynesia',
+    iata: 'PPT',
+    continent: 'Oceania',
+    geo: PAPEETE,
+    via: [[-118.4, 33.94]], // the long way west, through Los Angeles
+    startDate: '2006-01-01',
+    endDate: '2009-01-01',
+    precision: 'year',
     status: 'lived',
-    region: 'California · Semester abroad',
-    note: 'A semester at UC Berkeley — the reason Plane Buddy exists.',
-    link: 'https://plane-buddy.vercel.app/',
+    region: 'Tahiti · Lived there',
+    note: 'Three years in the South Pacific, and the reason for everything below.',
   },
   {
-    id: 'seoul-2024',
-    city: 'Seoul',
-    country: 'South Korea',
-    iata: 'ICN',
-    continent: 'Asia',
-    geo: [126.98, 37.57],
-    via: [
-      [19.0, 47.5], // Hungary
-      [33.0, 40.0], // central Türkiye
-      [52.0, 40.5], // Caspian / Turkmenistan
-      [67.0, 42.5], // Uzbekistan
-      [87.0, 44.0], // Ürümqi, Xinjiang
-      [110.0, 41.5], // Inner Mongolia
-    ],
-    startDate: '2024-05-04', // check the real dates
-    endDate: '2024-05-18',
-    region: 'South Korea',
-    note: 'Two weeks of Korean food, which I have been talking about ever since.',
+    id: 'sydney-2007',
+    city: 'Sydney',
+    country: 'Australia',
+    iata: 'SYD',
+    continent: 'Oceania',
+    geo: [151.21, -33.87],
+    origin: { code: 'PPT', city: 'Papeete', geo: PAPEETE },
+    via: [[174.76, -36.85]], // Auckland
+    startDate: '2007-01-01',
+    precision: 'year',
+    region: 'Australia · From Tahiti',
+  },
+  {
+    id: 'san-diego-2009',
+    city: 'San Diego',
+    country: 'United States',
+    iata: 'SAN',
+    continent: 'North America',
+    geo: [-117.16, 32.72],
+    origin: { code: 'PPT', city: 'Papeete', geo: PAPEETE },
+    startDate: '2009-01-01',
+    precision: 'year',
+    region: 'California · From Tahiti',
+  },
+  {
+    id: 'new-york-2009',
+    city: 'New York',
+    country: 'United States',
+    iata: 'JFK',
+    continent: 'North America',
+    geo: [-74.01, 40.71],
+    startDate: '2009-01-01',
+    precision: 'year',
+    region: 'New York · The way home',
   },
 
-  // ─── SAMPLES — replace these with your own trips ──────────────────────────
+  // ─── Europe ───────────────────────────────────────────────────────────────
   {
-    id: 'lisbon-2022',
+    id: 'london-2015',
+    city: 'London',
+    country: 'United Kingdom',
+    iata: 'LHR',
+    continent: 'Europe',
+    geo: [-0.13, 51.51],
+    startDate: '2015-01-01',
+    precision: 'year',
+    region: 'United Kingdom',
+  },
+  {
+    id: 'dublin-2016',
+    city: 'Dublin',
+    country: 'Ireland',
+    iata: 'DUB',
+    continent: 'Europe',
+    geo: [-6.26, 53.35],
+    startDate: '2016-01-01',
+    precision: 'year',
+    region: 'Ireland',
+  },
+  {
+    id: 'dublin-2017',
+    city: 'Dublin',
+    country: 'Ireland',
+    iata: 'DUB',
+    continent: 'Europe',
+    geo: [-6.26, 53.35],
+    startDate: '2017-01-01',
+    precision: 'year',
+    region: 'Ireland · Again',
+  },
+  {
+    id: 'fort-de-france-2017',
+    city: 'Fort-de-France',
+    country: 'Martinique',
+    iata: 'FDF',
+    continent: 'North America',
+    geo: [-61.07, 14.6],
+    startDate: '2017-01-01',
+    precision: 'year',
+    region: 'Martinique · Caribbean',
+  },
+  {
+    id: 'miami-2018',
+    city: 'Miami',
+    country: 'United States',
+    iata: 'MIA',
+    continent: 'North America',
+    geo: [-80.19, 25.76],
+    startDate: '2018-01-01',
+    precision: 'year',
+    region: 'Florida',
+  },
+  {
+    id: 'lisbon-2019',
     city: 'Lisbon',
     country: 'Portugal',
     iata: 'LIS',
     continent: 'Europe',
     geo: [-9.14, 38.72],
-    startDate: '2022-04-08',
-    endDate: '2022-04-13',
+    startDate: '2019-01-01',
+    precision: 'year',
     region: 'Portugal',
   },
   {
-    id: 'rome-2023',
-    city: 'Rome',
+    id: 'venice-2019',
+    city: 'Venice',
     country: 'Italy',
-    iata: 'FCO',
+    iata: 'VCE',
     continent: 'Europe',
-    geo: [12.5, 41.9],
-    startDate: '2023-03-02',
-    endDate: '2023-03-06',
+    geo: [12.34, 45.44],
+    startDate: '2019-01-01',
+    precision: 'year',
     region: 'Italy',
   },
   {
-    id: 'tokyo-2025',
-    city: 'Tokyo',
-    country: 'Japan',
-    iata: 'HND',
-    continent: 'Asia',
-    geo: [139.69, 35.69],
-    via: [
-      [19.0, 47.5], // Hungary
-      [33.0, 40.0], // central Türkiye
-      [52.0, 40.5], // Caspian / Turkmenistan
-      [67.0, 42.5], // Uzbekistan
-      [87.0, 44.0], // Ürümqi, Xinjiang
-      [110.0, 41.5], // Inner Mongolia
-    ],
-    startDate: '2025-04-11',
-    endDate: '2025-04-24',
-    region: 'Japan',
-  },
-  {
-    id: 'marrakech-2025',
-    city: 'Marrakech',
-    country: 'Morocco',
-    iata: 'RAK',
-    continent: 'Africa',
-    geo: [-7.98, 31.63],
-    startDate: '2025-11-06',
-    endDate: '2025-11-10',
-    region: 'Morocco',
-  },
-  {
-    id: 'lisbon-2026',
-    city: 'Porto',
-    country: 'Portugal',
-    iata: 'OPO',
+    id: 'bastia-2019',
+    city: 'Bastia',
+    country: 'France',
+    iata: 'BIA',
     continent: 'Europe',
-    geo: [-8.61, 41.15],
-    startDate: '2026-10-09',
-    endDate: '2026-10-13',
-    region: 'Portugal · Long weekend',
-    note: 'Four days, no plan beyond the list of places to eat.',
+    geo: [9.45, 42.7],
+    startDate: '2019-01-01',
+    precision: 'year',
+    region: 'Corsica',
   },
   {
-    id: 'seoul-2026',
+    id: 'athens-2021',
+    city: 'Athens',
+    country: 'Greece',
+    iata: 'ATH',
+    continent: 'Europe',
+    geo: [23.73, 37.98],
+    startDate: '2021-01-01',
+    precision: 'year',
+    region: 'Greece',
+  },
+
+  // ─── California ───────────────────────────────────────────────────────────
+  {
+    id: 'san-francisco-2022',
+    city: 'San Francisco',
+    country: 'United States',
+    iata: 'SFO',
+    continent: 'North America',
+    geo: [-122.42, 37.77],
+    startDate: '2022-01-01',
+    precision: 'year',
+    region: 'California',
+  },
+  {
+    id: 'san-francisco-2023',
+    city: 'San Francisco',
+    country: 'United States',
+    iata: 'SFO',
+    continent: 'North America',
+    geo: [-122.42, 37.77],
+    startDate: '2023-08-01',
+    endDate: '2023-12-01',
+    precision: 'month',
+    status: 'lived',
+    region: 'Berkeley · Exchange semester',
+    note: 'Four months at UC Berkeley — the reason Plane Buddy exists.',
+    link: 'https://plane-buddy.vercel.app/',
+  },
+
+  // ─── Asia ─────────────────────────────────────────────────────────────────
+  {
+    id: 'seoul-2024-first',
     city: 'Seoul',
     country: 'South Korea',
     iata: 'ICN',
     continent: 'Asia',
     geo: [126.98, 37.57],
-    via: [
-      [19.0, 47.5], // Hungary
-      [33.0, 40.0], // central Türkiye
-      [52.0, 40.5], // Caspian / Turkmenistan
-      [67.0, 42.5], // Uzbekistan
-      [87.0, 44.0], // Ürümqi, Xinjiang
-      [110.0, 41.5], // Inner Mongolia
-    ],
-    startDate: '2026-12-19',
-    endDate: '2027-01-03',
-    region: 'South Korea · Round two',
-    note: 'Going back in winter this time.',
+    via: VIA_KOREA,
+    startDate: '2024-01-01',
+    precision: 'year',
+    region: 'South Korea · First time',
+  },
+  {
+    id: 'seoul-2024-second',
+    city: 'Seoul',
+    country: 'South Korea',
+    iata: 'ICN',
+    continent: 'Asia',
+    geo: [126.98, 37.57],
+    via: VIA_KOREA,
+    startDate: '2024-01-01',
+    precision: 'year',
+    region: 'South Korea · Straight back',
+  },
+  {
+    id: 'shanghai-2025',
+    city: 'Shanghai',
+    country: 'China',
+    iata: 'PVG',
+    continent: 'Asia',
+    geo: SHANGHAI,
+    via: VIA_SHANGHAI,
+    startDate: '2025-01-01',
+    precision: 'year',
+    region: 'China',
+  },
+  {
+    id: 'taipei-2025',
+    city: 'Taipei',
+    country: 'Taiwan',
+    iata: 'TPE',
+    continent: 'Asia',
+    geo: [121.56, 25.03],
+    origin: { code: 'PVG', city: 'Shanghai', geo: SHANGHAI },
+    startDate: '2025-01-01',
+    precision: 'year',
+    region: 'Taiwan · Out of Shanghai',
+  },
+  {
+    id: 'london-2025',
+    city: 'London',
+    country: 'United Kingdom',
+    iata: 'LHR',
+    continent: 'Europe',
+    geo: [-0.13, 51.51],
+    startDate: '2025-01-01',
+    precision: 'year',
+    region: 'United Kingdom · Again',
+  },
+  {
+    id: 'seoul-2025',
+    city: 'Seoul',
+    country: 'South Korea',
+    iata: 'ICN',
+    continent: 'Asia',
+    geo: [126.98, 37.57],
+    via: VIA_KOREA,
+    startDate: '2025-01-01',
+    precision: 'year',
+    region: 'South Korea · Third run',
+  },
+
+  // ─── Upcoming ─────────────────────────────────────────────────────────────
+  {
+    id: 'hong-kong-2026',
+    city: 'Hong Kong',
+    country: 'Hong Kong',
+    iata: 'HKG',
+    continent: 'Asia',
+    geo: [114.17, 22.32],
+    via: VIA_HONG_KONG,
+    // Only the month is known. The days are placeholders that keep the trip on
+    // the Departures board and are never printed — swap in the real ones and
+    // drop `precision` to have the board count down to them properly.
+    startDate: '2026-08-20',
+    endDate: '2026-08-30',
+    precision: 'month',
+    region: 'First time · Booked',
+    note: 'Twelve hours the long way round Russia, and a first look at Hong Kong.',
   },
 ];
 
@@ -215,7 +422,7 @@ export type DerivedTrip = Trip & {
   phase: Phase;
   /** Days until departure; 0 once it has started. */
   daysAway: number;
-  /** Nights on the ground, 0 for a single day or an open-ended stay. */
+  /** Nights on the ground, 0 unless the exact dates are known. */
   nights: number;
   /** Fake-but-consistent flight number, e.g. "TC 0814". */
   flight: string;
@@ -236,21 +443,49 @@ const DAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
 export const pad2 = (n: number): string => String(n).padStart(2, '0');
 
+export const precisionOf = (trip: Trip): Precision => trip.precision ?? 'day';
+
 /** "2023-08-14" → "14 AUG" */
 export const formatDay = (iso: string): string => {
   const d = new Date(parseISO(iso));
   return `${pad2(d.getUTCDate())} ${MONTHS[d.getUTCMonth()]}`;
 };
 
-/** "2023-08-14" + "2023-12-15" → "14 AUG – 15 DEC", collapsing a shared month. */
+/** The departure cell: as much of the start date as is actually known. */
+export const formatStart = (trip: Trip): string => {
+  const d = new Date(parseISO(trip.startDate));
+  const precision = precisionOf(trip);
+  if (precision === 'year') return String(d.getUTCFullYear());
+  if (precision === 'month') return MONTHS[d.getUTCMonth()];
+  return formatDay(trip.startDate);
+};
+
+/**
+ * The arrival cell. "14 AUG – 15 DEC" when the days are known, "AUG – DEC" or
+ * just "2019" when they are not — the year divider above the row carries the
+ * rest, so nothing here has to be invented to fill the column.
+ */
 export const formatRange = (trip: Trip): string => {
-  if (!trip.endDate || trip.endDate === trip.startDate) return formatDay(trip.startDate);
+  const precision = precisionOf(trip);
   const start = new Date(parseISO(trip.startDate));
-  const end = new Date(parseISO(trip.endDate));
-  if (
-    start.getUTCMonth() === end.getUTCMonth() &&
-    start.getUTCFullYear() === end.getUTCFullYear()
-  ) {
+  const end = trip.endDate ? new Date(parseISO(trip.endDate)) : null;
+  const sameYear = end ? start.getUTCFullYear() === end.getUTCFullYear() : true;
+
+  if (precision === 'year') {
+    if (end && !sameYear) return `${start.getUTCFullYear()} – ${end.getUTCFullYear()}`;
+    return String(start.getUTCFullYear());
+  }
+
+  if (precision === 'month') {
+    const from = MONTHS[start.getUTCMonth()];
+    if (!end) return from;
+    const to = MONTHS[end.getUTCMonth()];
+    if (from === to && sameYear) return from;
+    return sameYear ? `${from} – ${to}` : `${from} ${start.getUTCFullYear()} – ${to}`;
+  }
+
+  if (!trip.endDate || trip.endDate === trip.startDate) return formatDay(trip.startDate);
+  if (end && start.getUTCMonth() === end.getUTCMonth() && sameYear) {
     return `${pad2(start.getUTCDate())}–${pad2(end.getUTCDate())} ${MONTHS[start.getUTCMonth()]}`;
   }
   return `${formatDay(trip.startDate)} – ${formatDay(trip.endDate)}`;
@@ -262,7 +497,17 @@ export const formatHeaderDate = (iso: string): string => {
   return `${DAYS[d.getUTCDay()]} ${pad2(d.getUTCDate())} ${MONTHS[d.getUTCMonth()]}`;
 };
 
-const flightNumber = (trip: Trip): string => `TC ${trip.startDate.slice(5).replace('-', '')}`;
+/**
+ * A flight number that stays put across builds. Day-precise trips get one from
+ * their date; the rest get a hash of their id, because half the board would
+ * otherwise be flight TC 0101.
+ */
+const flightNumber = (trip: Trip): string => {
+  if (precisionOf(trip) === 'day') return `TC ${trip.startDate.slice(5).replace('-', '')}`;
+  let hash = 0;
+  for (let i = 0; i < trip.id.length; i += 1) hash = (hash * 31 + trip.id.charCodeAt(i)) % 9000;
+  return `TC ${pad2(hash + 1000)}`;
+};
 
 const EARTH_RADIUS_KM = 6371;
 
@@ -318,6 +563,10 @@ export const groupPlaces = (trips: DerivedTrip[]): Place[] => {
   return grouped;
 };
 
+/** Where a leg took off from — home, unless the trip says otherwise. */
+export const originGeo = (trip: Trip, homeGeo: [number, number]): [number, number] =>
+  trip.origin?.geo ?? homeGeo;
+
 /**
  * Distance actually flown: the sum of the legs through any waypoints, so a
  * route bent around closed airspace reports the longer figure it really is.
@@ -338,11 +587,13 @@ const phaseOf = (trip: Trip, todayISO: string): Phase => {
 
 export const derive = (trip: Trip, todayISO: string): DerivedTrip => {
   const end = trip.endDate ?? trip.startDate;
+  const exact = precisionOf(trip) === 'day';
   return {
     ...trip,
     phase: phaseOf(trip, todayISO),
     daysAway: Math.max(0, daysBetween(todayISO, trip.startDate)),
-    nights: trip.endDate ? Math.max(0, daysBetween(trip.startDate, end)) : 0,
+    // Counting nights off a date we rounded to the month would be fiction.
+    nights: trip.endDate && exact ? Math.max(0, daysBetween(trip.startDate, end)) : 0,
     flight: flightNumber(trip),
     year: Number(trip.startDate.slice(0, 4)),
   };
@@ -374,6 +625,8 @@ export const buildBoards = (todayISO: string, trips: Trip[] = TRIPS): JourneyBoa
 
   const home = derived.find((t) => t.phase === 'resident') ?? null;
 
+  // Year-only trips inside the same year all sort equal, so the stable sort
+  // leaves them in the order TRIPS lists them.
   const landed = derived
     .filter((t) => t.phase === 'landed' || t.phase === 'enroute')
     .sort((a, b) => b.startDate.localeCompare(a.startDate));

--- a/pages/journey/index.tsx
+++ b/pages/journey/index.tsx
@@ -10,8 +10,9 @@ import {
   HOME_CODE,
   HOME_NAME,
   buildBoards,
-  formatDay,
   formatRange,
+  formatStart,
+  precisionOf,
 } from '../../lib/journey';
 
 type Props = { todayISO: string };
@@ -56,7 +57,9 @@ const STATUS_STYLES: Record<string, string> = {
 const departureStatus = (trip: DerivedTrip): { text: string; kind: string; sub?: string } => {
   if (trip.phase === 'boarding') return { text: 'Boarding', kind: 'boarding' };
   if (trip.phase === 'enroute') return { text: 'En route', kind: 'enroute' };
-  return { text: 'On time', kind: 'ontime', sub: `in ${trip.daysAway}d` };
+  // A countdown off a date rounded to the month would be made up to the day.
+  const sub = precisionOf(trip) === 'day' ? `in ${trip.daysAway}d` : undefined;
+  return { text: 'On time', kind: 'ontime', sub };
 };
 
 const toDepartureRow = (trip: DerivedTrip): BoardRow => {
@@ -65,7 +68,7 @@ const toDepartureRow = (trip: DerivedTrip): BoardRow => {
     key: trip.id,
     href: trip.link,
     cells: [
-      { content: formatDay(trip.startDate), className: WHEN },
+      { content: formatStart(trip), className: WHEN },
       { content: trip.city, className: CITY, sub: trip.region ?? trip.country },
       { content: trip.flight, className: FLIGHT },
       {


### PR DESCRIPTION
Follow-up to #21. That PR shipped the board with sample destinations; this one replaces them with the real thing — 22 trips from 2006 to the Hong Kong flight this month. Nothing on the board is invented any more.

Still not linked from the home page. `/journey` stays reachable directly.

**18 cities · 14 countries · 4 continents · since 2006.** Territories count separately, so Papeete is French Polynesia and Fort-de-France is Martinique. If you would rather count both as France, change the `country` field and the header stat follows.

## Dates print only what is known

Most of these trips were remembered as a year and nothing finer. Rather than invent days to fill the column, `Trip` now carries a `precision` of `'day' | 'month' | 'year'`, and every formatter prints to that precision and no further:

| precision | Arrivals column | Departures column |
|---|---|---|
| `year` | `2019` | `2019` |
| `month` | `AUG – DEC` | `AUG` |
| `day` | `14 AUG – 15 DEC` | `14 AUG` |

The same rule suppresses everything else that would be fiction at a coarser precision: no night counts, and no `in 12d` countdown — a month-precision trip reads `Departs AUG` instead. Flight numbers now come from a hash of the trip id rather than the date, so half the board is not flight `TC 0101`.

Pin down a real date, drop the `precision` field, and the board starts printing it with no other change.

**Worth a look before this merges:** Hong Kong carries placeholder days (20–30 August). They are never printed, but they do decide whether it sits on Departures or reads as already in progress — so if you have the real dates, that is the one line to fix.

## Legs that did not start in Paris

Three of them: Sydney and San Diego left from Papeete, Taipei from Shanghai. The new `Trip.origin` moves the arc's start point on the globe and names it in the caption, so the route map draws `PPT → SYD` instead of pretending everything radiates out of Paris. The arc cache key now covers the whole route, not just its endpoint, since two trips can land in the same city from different places.

## Flight paths

Routes are great circles unless a trip lists `via` waypoints. Everything to Asia since 2022 does, because those flights bow a long way south of Russia — Paris–Seoul comes out at 10,548 km against 8,970 direct. Seoul, Shanghai and Hong Kong each get their own waypoints, since they diverge once across Xinjiang. Approximate published routings, not recorded tracks; the public ADS-B APIs do not reach back far enough for the real ones.

## Checked

`tsc --noEmit` and `next build` clean, `/journey` still prerenders as SSG with a 1h revalidate. Verified in a headless browser: captions read `PPT → SYD · 6,249 km` and `PVG → TPE · 689 km`, the expanded map's Seoul marker reports 3 trips across 2025/2024/2024, and no console errors.

The globe tooltip no longer prints the year twice for year-only trips.
